### PR TITLE
Upgrade goblin to 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/messense/fat-macho-rs.git"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-goblin = "0.8.0"
+goblin = "0.9.0"
 llvm-bitcode = { version = "0.1.1", optional = true }
 
 [features]


### PR DESCRIPTION
The breaking change from 0.8.0 appears to be the addition of a value to a pub enum associated with TE (terse executable) support; this does not look like it should affect fat-macho-rs’s usage of goblin since it doesn’t match exhaustively on this enum.

Furthermore, `cargo test` passes, and `cd python/; python3 -m build` still works.

https://github.com/m4b/goblin/blob/d096260201158ed34d64728fd1ab0ca125e2f956/CHANGELOG.md#092----2024-10-26